### PR TITLE
Correct fontface link for bold text

### DIFF
--- a/client/src/styles/partials/_typography.scss
+++ b/client/src/styles/partials/_typography.scss
@@ -9,7 +9,7 @@
 
 @font-face {
   font-family: $font-family;
-  src: url("../../../public/assets/fonts/Sen-Regular.ttf") format("truetype");
+  src: url("../../../public/assets/fonts/Sen-Bold.ttf") format("truetype");
   font-weight: 600;
   font-style: normal;
 }


### PR DESCRIPTION
- Url for boldface was linking to regular ttf, corrected